### PR TITLE
Bring the community links to the right level

### DIFF
--- a/documentation/getting-started.asciidoc
+++ b/documentation/getting-started.asciidoc
@@ -54,4 +54,4 @@ include::guide-sample-application[leveloffset=+1]
 
 include::further-info-repo-overview[leveloffset=+1]
 
-include::further-info-community-links[leveloffset+1]
+include::further-info-community-links[leveloffset=+1]


### PR DESCRIPTION
The community links are displayed in the left side navigation, because
they're a level 1 heading due to the wrong leveloffset option.

Adding the '=' sign should fix this.